### PR TITLE
Nilearn compatibility: tr > t_r

### DIFF
--- a/prfpy/model.py
+++ b/prfpy/model.py
@@ -79,17 +79,17 @@ class Model(object):
                 [
                     np.ones_like(hrf_params[1], dtype='float32')*hrf_params[0] *
                     spm_hrf(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis],
                     hrf_params[1] *
                     spm_time_derivative(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis],
                     hrf_params[2] *
                     spm_dispersion_derivative(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis]],
                         dtype='float32').sum(

--- a/prfpy/model.py
+++ b/prfpy/model.py
@@ -52,17 +52,17 @@ class Model(object):
                 [
                     np.ones_like(hrf_params[1], dtype='float32')*hrf_params[0] *
                     spm_hrf(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis],
                     hrf_params[1] *
                     spm_time_derivative(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis],
                     hrf_params[2] *
                     spm_dispersion_derivative(
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         oversampling=1,
                         time_length=40)[...,np.newaxis]],
                         dtype='float32').sum(
@@ -70,7 +70,7 @@ class Model(object):
         elif hrf_basis.lower() == 'tdm':
 
             hrf =  tdm_hrf(hrf_params[1],
-                        tr=self.stimulus.TR,
+                        t_r=self.stimulus.TR,
                         time_length=40)                  
             
         else:

--- a/prfpy/timecourse.py
+++ b/prfpy/timecourse.py
@@ -8,7 +8,7 @@ from statsmodels.tsa.arima_process import arma_generate_sample
 fpath = os.path.dirname(os.path.realpath(__file__))
 hrf_library = np.genfromtxt(os.path.join(fpath,"tdm_hrfs_highsample.tsv"), delimiter="\t")
 
-def tdm_hrf(hrf_param,tr,time_length):
+def tdm_hrf(hrf_param,t_r,time_length):
 
     if isinstance(hrf_param,np.ndarray) or isinstance(hrf_param,list):
         hrf_param = np.array([int(h_p*2) for h_p in hrf_param])
@@ -19,7 +19,7 @@ def tdm_hrf(hrf_param,tr,time_length):
     hrf_param[hrf_param>19] = 19
     hrf_param[hrf_param<0] = 0
 
-    downsample = int(tr/0.01)
+    downsample = int(t_r/0.01)
     #to match spm
     this_time_length = int((time_length-1)/0.01)
 


### PR DESCRIPTION
Also did `t_r` for `tdm_hrf` for consistency-sake.